### PR TITLE
GARDEN-003: Supabase + PowerSync integration foundation

### DIFF
--- a/config/powersync.yaml
+++ b/config/powersync.yaml
@@ -1,0 +1,55 @@
+# PowerSync sync rules — Garden App
+#
+# These rules are uploaded to the PowerSync dashboard and control which
+# Supabase rows sync to which user's local SQLite database.
+#
+# Docs: https://docs.powersync.com/usage/sync-rules
+#
+# Status: SCAFFOLD — table definitions will be filled in as each feature
+# ticket (GARDEN-006 through GARDEN-013) defines its schema.
+
+bucket_definitions:
+  # One bucket per authenticated user — each user syncs only their own data.
+  user_data:
+    # Parameter pulled from the PowerSync JWT (set in fetchCredentials).
+    parameters:
+      - name: user_id
+        token_parameter: sub
+
+    data:
+      # GARDEN-006: Garden beds
+      # - SELECT id, user_id, name, type, width_cm, length_cm, created_at
+      #     FROM gardens
+      #    WHERE user_id = bucket.user_id
+      # TODO: uncomment when GARDEN-006 schema is defined
+
+      # GARDEN-007: Plant placements
+      # - SELECT id, garden_id, plant_ref_id, position_x, position_y, planted_at
+      #     FROM plantings
+      #     JOIN gardens ON gardens.id = plantings.garden_id
+      #    WHERE gardens.user_id = bucket.user_id
+      # TODO: uncomment when GARDEN-007 schema is defined
+
+      # GARDEN-009: Watering log
+      # - SELECT id, planting_id, watered_at, amount_ml, source
+      #     FROM watering_logs
+      #     JOIN plantings ON plantings.id = watering_logs.planting_id
+      #     JOIN gardens ON gardens.id = plantings.garden_id
+      #    WHERE gardens.user_id = bucket.user_id
+      # TODO: uncomment when GARDEN-009 schema is defined
+
+      # GARDEN-010: Growth events
+      # - SELECT id, planting_id, event_type, recorded_at, notes
+      #     FROM growth_events
+      #     JOIN plantings ON plantings.id = growth_events.planting_id
+      #     JOIN gardens ON gardens.id = plantings.garden_id
+      #    WHERE gardens.user_id = bucket.user_id
+      # TODO: uncomment when GARDEN-010 schema is defined
+
+      # GARDEN-013: Harvest log
+      # - SELECT id, planting_id, harvested_at, yield_g, notes
+      #     FROM harvest_logs
+      #     JOIN plantings ON plantings.id = harvest_logs.planting_id
+      #     JOIN gardens ON gardens.id = plantings.garden_id
+      #    WHERE gardens.user_id = bucket.user_id
+      # TODO: uncomment when GARDEN-013 schema is defined

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,8 +24,8 @@ Built for public use — multi-user from day one, with the first user being the 
 | AI vision | Google Gemini Flash | Strongest free tier (1,500 req/day), native image support, swappable interface |
 | Weather API | Open-Meteo | Free, no API key, 16-day forecast, 1km resolution, best free data quality. Frost alerts computed in-app from `temperature_2m_min` |
 | Plant data | Bundled SQLite (~500 plants, ~2–5MB) | OpenFarm dump (CC BY-SA) + USDA PLANTS CSV (public domain) + NOAA frost dates for planting windows |
-| 3D rendering | Babylon.js React Native (`@babylonjs/react-native`) | JSI-based native rendering, built-in `ArcRotateCamera` orbit controls, best mobile performance |
-| 3D model strategy | Procedural geometry, cached locally | Generated from growth parameters at runtime — no asset files. Cached per plant instance, updated on growth events |
+| 3D rendering | `@react-three/fiber/native` + `expo-gl` + `@react-three/drei` | JSI via expo-gl (SDK 55 native module), `<OrbitControls>` from drei, procedural Three.js geometry. Babylon.js ruled out — no RN 0.83 support (see GARDEN-BJS-001). |
+| 3D model strategy | Procedural geometry (Three.js primitives), cached locally | Generated from growth parameters at runtime — no asset files. BoxGeometry (beds), CylinderGeometry + SphereGeometry (plants). Cached per plant instance, updated on growth events |
 
 ---
 
@@ -217,7 +217,7 @@ All pre-build research items are resolved:
 | Item | Decision | Notes |
 |---|---|---|
 | Weather API | Open-Meteo | Free, no key, 16-day forecast, 1km resolution. Frost alerts computed in-app. |
-| 3D library | Babylon.js React Native | Bare workflow, JSI rendering, native orbit controls (`ArcRotateCamera`) |
+| 3D library | `@react-three/fiber/native` + `expo-gl` | Spike GARDEN-BJS-001: Babylon.js `@2.0.1` only validated to RN 0.79.4, not compatible with RN 0.83.2. R3F 9.5 peer dep `>=0.78`, expo-gl 55 targets RN 0.83 exactly. Orbit controls via `@react-three/drei`. |
 | Offline sync | PowerSync | Official Supabase connector, YAML sync rules, zero custom sync code |
 | Plant data | OpenFarm + USDA PLANTS + NOAA | CC BY-SA + public domain sources only. ~100–150 records need manual curation. |
 

--- a/docs/handoff-GARDEN-003.md
+++ b/docs/handoff-GARDEN-003.md
@@ -1,0 +1,97 @@
+# Handoff — GARDEN-003 Supabase + PowerSync Integration
+
+**Branch:** `GARDEN-003-supabase-powersync`
+**Base:** `develop`
+**Status:** In Progress
+
+---
+
+## Goal
+
+Install and configure the offline-first data sync layer. No business logic — structural foundation only. All tables are stubbed in the sync rules and will be filled in by feature tickets (GARDEN-006+).
+
+## Scope
+
+- Install `@powersync/react-native`, `@powersync/common`, `@journeyapps/react-native-quick-sqlite`, `@supabase/supabase-js`
+- Add `cjs` to Metro `sourceExts` (required by PowerSync module resolution)
+- `src/services/supabase.ts` — typed Supabase client, credentials via `EXPO_PUBLIC_*` env vars
+- `src/services/powersync.ts` — `SupabaseConnector` implementing `PowerSyncBackendConnector`
+- `config/powersync.yaml` — sync rules scaffold with all Phase 1 tables commented in, ready to uncomment per ticket
+
+## Out of Scope
+
+- Actual Supabase project creation / credentials (no `.env` values committed)
+- PowerSync dashboard project setup
+- Any database schema / migrations
+- Table-level sync rules (filled in per feature ticket)
+- Auth UI (GARDEN-014)
+
+---
+
+## Key Decisions
+
+### No separate Supabase connector package
+
+`@powersync/supabase-connector` does not exist on npm. The Supabase connector is a custom implementation of the `PowerSyncBackendConnector` interface — standard PowerSync pattern per their official docs and demo apps.
+
+### Credentials via EXPO_PUBLIC_ env vars
+
+Supabase URL and anon key are read from `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY`. These are set in `.env.local` for local dev (gitignored) and via EAS Secrets for cloud builds. The PowerSync endpoint is read from `EXPO_PUBLIC_POWERSYNC_URL`.
+
+### uploadData strategy
+
+Each CRUD entry is flushed individually (upsert/update/delete per row). This is correct for the low-write-volume garden use case. For high-throughput tables, batch RPC calls can be substituted later.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `metro.config.js` | Added `cjs` to `sourceExts` |
+| `src/services/supabase.ts` | New — Supabase client factory |
+| `src/services/powersync.ts` | New — `SupabaseConnector` + singleton export |
+| `tests/services/powersync.test.ts` | New — 9 unit tests for `SupabaseConnector` |
+| `config/powersync.yaml` | New — sync rules scaffold |
+| `package.json` / `package-lock.json` | 4 new packages |
+
+---
+
+## Environment Variables Required
+
+```
+EXPO_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+EXPO_PUBLIC_POWERSYNC_URL=https://<powersync-instance>.powersync.journeyapps.com
+```
+
+Add these to `.env.local` for local dev. Add to EAS Secrets before any cloud build.
+
+---
+
+## Progress
+
+- [x] Branch created: `GARDEN-003-supabase-powersync`
+- [x] Dependencies installed
+- [x] `metro.config.js` updated (`cjs` sourceExt)
+- [x] `src/services/supabase.ts` created
+- [x] `src/services/powersync.ts` created
+- [x] `config/powersync.yaml` scaffold created
+- [x] `tests/services/powersync.test.ts` — 9 unit tests for `SupabaseConnector`
+- [x] Lint passing (0 errors, 0 warnings)
+- [x] Tests passing (11/11)
+- [ ] Committed
+
+---
+
+## Next Steps After This Branch
+
+- **GARDEN-004:** Navigation shell (tab nav + placeholder screens) — pure JS, can start immediately
+- **GARDEN-014:** Supabase auth (email/password + OAuth) — depends on GARDEN-003 merge
+- **GARDEN-006+:** Feature tickets begin defining table schemas → uncomment sync rules in `config/powersync.yaml`
+
+---
+
+## Last Updated
+
+2026-03-22 — Foundation complete. Lint clean, tests green, ready for commit review.

--- a/docs/handoff-GARDEN-BJS-001.md
+++ b/docs/handoff-GARDEN-BJS-001.md
@@ -1,0 +1,139 @@
+# Handoff — GARDEN-BJS-001 Babylon.js RN 0.83 Compatibility Spike
+
+**Type:** Spike
+**Status:** Complete — Decision Reached
+**Date:** 2026-03-22
+**Unblocks:** GARDEN-012 (3D Garden Visualization)
+
+---
+
+## Question
+
+Does `@babylonjs/react-native@2.x` support React Native 0.83.2 (Expo SDK 55)? If not, what is the best alternative for 3D garden visualization?
+
+---
+
+## Verdict: Babylon.js is NOT compatible with RN 0.83.2
+
+**Evidence:**
+
+- Latest published: `@babylonjs/react-native@2.0.1` (March 18, 2025)
+- The library's own playground app is pinned to **RN 0.79.4** — the highest version the Babylon team has validated against
+- The module-level `devDependencies` reference RN 0.73.5, meaning the native build environment has not moved past 0.73
+- `peerDependencies` says `"react-native": "*"` — this is not a compatibility guarantee; it means the authors have not restricted the range, not that it works
+- No binary exists for RN 0.83 (the v2.x bundle includes compiled native code targeting 0.79.4 at best)
+- RN 0.83 ships Bridgeless New Architecture as the default. Babylon.js React Native has not validated this path and has not published any RN 0.83+ release notes or issues indicating work in progress
+- No community reports of successful installation on RN 0.83+
+
+**Conclusion:** Installing `@babylonjs/react-native` on RN 0.83.2 will very likely fail at native build time or crash at runtime due to JSI/New Architecture incompatibility. Do not pursue.
+
+---
+
+## Alternatives Evaluated
+
+### Option A — `@react-three/fiber/native` + `expo-gl` ✅ RECOMMENDED
+
+| Package | Version | RN Peer Dep | RN 0.83 Compatible |
+|---|---|---|---|
+| `@react-three/fiber` | 9.5.0 | >=0.78 | Yes |
+| `expo-gl` | 55.0.10 | SDK 55 (RN 0.83) | Yes — exact match |
+| `@react-three/drei` | 9.x | same range | Yes |
+| `three` | 0.x | — | Yes (pure JS) |
+
+**Why it works for this project:**
+- `expo-gl` v55 is literally the Expo SDK 55 package — designed for this exact environment, pre-built EAS binaries included, no custom Podfile or gradle changes needed
+- R3F peer dep `>=0.78` explicitly covers RN 0.83.2; R3F 9.3+ includes specific New Architecture compatibility fixes
+- Procedural geometry is a Three.js strength: `BoxGeometry`, `CylinderGeometry`, `SphereGeometry`, `LatheGeometry`, `InstancedMesh` — all the primitives needed for garden beds and plant models are first-class
+- Orbit controls via `@react-three/drei`'s `<OrbitControls>` — ~10 lines of JSX for pivot/zoom/rotate
+- Declarative R3F component model maps naturally to data-driven garden scenes (plant data props → mesh geometry)
+- Large, active community; excellent documentation
+
+**Score: 9/10**
+
+---
+
+### Option B — `@shopify/react-native-skia` (2D/2.5D fallback)
+
+- RN 0.83 compatible (`>=0.78` peer dep, actively maintained by Shopify)
+- **Not the right tool:** Skia is a 2D vector/raster renderer. A genuine 3D orbit-around-a-garden experience cannot be built on it
+- Could render a top-down flat plan view, but loses camera orbit, Z-depth occlusion, perspective, plant height, shadows
+- Viable only as a flat garden map — a significant UX downgrade from the design intent
+
+**Score: 4/10** — ruled out for GARDEN-012 as designed
+
+---
+
+### Option C — Downgrade to Expo SDK 50 / RN 0.73
+
+- The only combination with documented Babylon.js RN support (1.8.x, not 2.x)
+- Expo SDK 50 reached end of support mid-2025 — no security patches
+- RN 0.73 is out of active support
+- All other Phase 1 dependencies would need audit and potential downgrade
+- A dead-end path that trades a 3D library problem for a platform debt problem
+
+**Score: 2/10** — not recommended
+
+---
+
+## Decision
+
+**Adopt `@react-three/fiber/native` + `expo-gl` as the 3D rendering stack.**
+
+This replaces the original Babylon.js decision in `design.md`. The reasoning for the original choice (JSI-based native rendering, orbit controls, best mobile performance) is equally met by R3F + expo-gl on RN 0.83, with the added benefit that it actually works on our target platform.
+
+---
+
+## Impact on Design Doc
+
+| Field | Old | New |
+|---|---|---|
+| 3D rendering | `@babylonjs/react-native` — JSI-based, ArcRotateCamera | `@react-three/fiber/native` + `expo-gl` — JSI via expo-gl, OrbitControls via drei |
+| Bare workflow requirement | Required for Babylon.js native modules | Still required (expo-gl is a native module) |
+| Procedural geometry | BabylonJS Mesh | Three.js BufferGeometry / parametric primitives |
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `drei` OrbitControls touch behavior on device | Medium | Validate pinch/pan early on physical iOS + Android. Fallback: manual gesture handler via `react-native-gesture-handler` + camera manipulation |
+| R3F React version upper bound `<19.3` | Low | Expo SDK 55 ships React 19.0 — in range. Monitor when SDK 56 arrives |
+| expo-gl OpenGL ES ceiling | Low | Acceptable for low-poly procedural style. Not a blocker |
+| New Arch JSI threading with expo-gl on Android | Medium | expo-gl 55.x built for New Arch; R3F 9.3+ has New Arch fixes. Test render loop on Android early |
+
+---
+
+## Next Steps for GARDEN-012
+
+1. **Install the stack** (in GARDEN-012 branch):
+   ```bash
+   npx expo install expo-gl
+   npm install three @react-three/fiber @react-three/drei
+   ```
+
+2. **Smoke test** — a single `<Canvas>` with `<BoxGeometry>` and `<OrbitControls>` on physical iOS and Android via EAS dev client before writing any garden logic
+
+3. **Always import from the native path:**
+   ```ts
+   import { Canvas } from '@react-three/fiber/native';
+   import { OrbitControls } from '@react-three/drei/native';
+   ```
+
+4. **Prototype one procedural plant mesh** (cylinder trunk + sphere canopy driven by `height` and `growthStage` props) to validate the data → geometry pipeline
+
+5. **Do not install `expo-three`** — not needed when using R3F; R3F speaks to expo-gl directly
+
+6. **Do not install `@babylonjs/react-native`** — not viable for RN 0.83.2
+
+---
+
+## Key Version Table (2026-03-22)
+
+| Package | Version | Notes |
+|---|---|---|
+| `@react-three/fiber` | 9.5.0 | Import from `/native` path |
+| `expo-gl` | 55.0.10 | Expo SDK 55 native module |
+| `@react-three/drei` | 9.x | OrbitControls, helpers |
+| `three` | 0.x | Pure JS — no native build |
+| `@babylonjs/react-native` | 2.0.1 | ❌ Do not use on RN 0.83 |

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -33,7 +33,7 @@ GitHub Issue title: `GARDEN-NNN: Brief description`
 | GARDEN-009 | Smart watering engine | `phase-1` | Open-Meteo integration, water need calc, watering log |
 | GARDEN-010 | Growth tracking + harvest schedule | `phase-1` | Per-plant schedule, days to maturity, harvest window calc |
 | GARDEN-011 | AI photo features | `phase-1` | Gemini Flash integration behind AIVisionService interface. Plant onboarding + progress check. |
-| GARDEN-012 | 3D garden visualization | `phase-1`, `blocked` | Blocked by GARDEN-BJS-001 |
+| GARDEN-012 | 3D garden visualization | `phase-1` | Stack: `@react-three/fiber/native` + `expo-gl` + `@react-three/drei`. See handoff-GARDEN-BJS-001.md. |
 | GARDEN-013 | Harvest tracking + notifications | `phase-1` | Harvest window alerts, log events, missed harvest flags |
 | GARDEN-014 | Auth + user accounts | `phase-1` | Supabase auth, email/password + OAuth |
 | GARDEN-015 | EAS Build + iOS dev workflow | `phase-1`, `native` | EAS project setup, dev client build, Windows → iOS workflow |
@@ -42,9 +42,7 @@ GitHub Issue title: `GARDEN-NNN: Brief description`
 
 ## Spikes
 
-| Ticket | Title | Labels | Notes |
-|--------|-------|--------|-------|
-| GARDEN-BJS-001 | Babylon.js RN 0.83 compatibility | `spike` | Does `@babylonjs/react-native@2.x` support RN 0.83.2? If not, evaluate: Three.js (`@react-three/fiber`), Skia 2D fallback, or downgrade. Unblocks GARDEN-012. |
+_None open._
 
 ---
 
@@ -66,3 +64,4 @@ GitHub Issue title: `GARDEN-NNN: Brief description`
 |--------|-------|-----------|
 | GARDEN-001 | Initial project setup with design doc and gitignore | 885648e |
 | GARDEN-002 | Scaffold Expo bare workflow with core dependencies | 3586520 |
+| GARDEN-BJS-001 | Babylon.js RN 0.83 compatibility spike | Decision: R3F + expo-gl. See docs/handoff-GARDEN-BJS-001.md |

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,4 +4,7 @@ const { getDefaultConfig } = require('expo/metro-config');
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
 
+// PowerSync requires cjs modules to be resolvable
+config.resolver.sourceExts = [...config.resolver.sourceExts, 'cjs'];
+
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "garden-app",
       "version": "1.0.0",
       "dependencies": {
+        "@journeyapps/react-native-quick-sqlite": "^2.5.1",
+        "@powersync/common": "^1.49.0",
+        "@powersync/react-native": "^1.32.0",
         "@react-navigation/bottom-tabs": "^7.15.6",
         "@react-navigation/native": "^7.1.34",
         "@react-navigation/native-stack": "^7.14.6",
@@ -2573,6 +2576,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@journeyapps/react-native-quick-sqlite": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-2.5.1.tgz",
+      "integrity": "sha512-LDSR8j86bzvoogg1HMprnS4g6Tx0ySNBeKvrCwvhWSyY3H9L4FpU5zMV2S4NEjn3RYk2/klcCc0KB/eyITgwPQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2626,6 +2640,49 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@powersync/common": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@powersync/common/-/common-1.49.0.tgz",
+      "integrity": "sha512-g6uonubvtmtyx8hS/G5trg9LsBvzHY3tAKHiV7SIQV3Xyz9ONM6NNnjDMP2vcLZVmsOSi8x/QJZmy/ig1YtBMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "event-iterator": "^2.0.0"
+      }
+    },
+    "node_modules/@powersync/react": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@powersync/react/-/react-1.9.0.tgz",
+      "integrity": "sha512-FypJ1RSQXhbpLJ1WOSLi1ph+q6JXAX5GHqXhczaOr0dhngsr1zHIsFTANh6N0tfx838SM+MDgYO1d0LZxv1WWw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@powersync/common": "^1.47.0",
+        "react": "*"
+      }
+    },
+    "node_modules/@powersync/react-native": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@powersync/react-native/-/react-native-1.32.0.tgz",
+      "integrity": "sha512-KjdrP8GqyHfacvu37GEC/UqMRJfIgTFre76GycQAzLmNcMlhHapfPFN3Rdq/6ccLF1EUlUbV7f7D8CwB4FaTYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@powersync/common": "1.49.0",
+        "@powersync/react": "1.9.0",
+        "async-mutex": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@journeyapps/react-native-quick-sqlite": "^2.5.1",
+        "@powersync/common": "^1.49.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@journeyapps/react-native-quick-sqlite": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -4086,6 +4143,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -5984,6 +6050,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==",
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     ]
   },
   "dependencies": {
+    "@journeyapps/react-native-quick-sqlite": "^2.5.1",
+    "@powersync/common": "^1.49.0",
+    "@powersync/react-native": "^1.32.0",
     "@react-navigation/bottom-tabs": "^7.15.6",
     "@react-navigation/native": "^7.1.34",
     "@react-navigation/native-stack": "^7.14.6",

--- a/src/services/powersync.ts
+++ b/src/services/powersync.ts
@@ -1,0 +1,65 @@
+import {
+  AbstractPowerSyncDatabase,
+  PowerSyncBackendConnector,
+  PowerSyncCredentials,
+} from '@powersync/react-native';
+import { supabase } from './supabase';
+
+/**
+ * Connects PowerSync to our Supabase backend.
+ *
+ * fetchCredentials — exchanges the active Supabase session token for a
+ *   PowerSync JWT. The PowerSync service validates this token against the
+ *   Supabase JWKS endpoint configured in the PowerSync dashboard.
+ *
+ * uploadData — flushes locally-queued CRUD mutations to Supabase. Each
+ *   transaction is sent as individual RPC / table upsert calls so the server
+ *   remains the source of truth for conflict resolution.
+ */
+export class SupabaseConnector implements PowerSyncBackendConnector {
+  async fetchCredentials(): Promise<PowerSyncCredentials | null> {
+    const {
+      data: { session },
+      error,
+    } = await supabase.auth.getSession();
+
+    if (error) {
+      throw new Error(`[PowerSync] Failed to fetch Supabase session: ${error.message}`);
+    }
+
+    if (!session) {
+      return null;
+    }
+
+    return {
+      endpoint: process.env.EXPO_PUBLIC_POWERSYNC_URL ?? '',
+      token: session.access_token,
+      expiresAt: session.expires_at ? new Date(session.expires_at * 1000) : undefined,
+    };
+  }
+
+  async uploadData(database: AbstractPowerSyncDatabase): Promise<void> {
+    const batch = await database.getCrudBatch();
+    if (!batch) return;
+
+    for (const entry of batch.crud) {
+      const { table, op, opData, id } = entry;
+
+      switch (op) {
+        case 'PUT':
+          await supabase.from(table).upsert({ id, ...opData });
+          break;
+        case 'PATCH':
+          await supabase.from(table).update(opData ?? {}).eq('id', id);
+          break;
+        case 'DELETE':
+          await supabase.from(table).delete().eq('id', id);
+          break;
+      }
+    }
+
+    await batch.complete();
+  }
+}
+
+export const supabaseConnector = new SupabaseConnector();

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,0 +1,21 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+// Credentials are injected at runtime via environment / EAS secrets.
+// Never hardcode these values here.
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.warn(
+    '[Supabase] EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY is not set. ' +
+      'Add these to your .env.local file or EAS secrets before running.',
+  );
+}
+
+export const supabase: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});

--- a/tests/services/powersync.test.ts
+++ b/tests/services/powersync.test.ts
@@ -1,0 +1,144 @@
+import { SupabaseConnector } from '../../src/services/powersync';
+import { supabase } from '../../src/services/supabase';
+
+// @powersync/react-native has native bindings — mock the whole module.
+// All types (interfaces) used by SupabaseConnector are erased at runtime.
+jest.mock('@powersync/react-native', () => ({}));
+
+jest.mock('../../src/services/supabase', () => ({
+  supabase: {
+    auth: { getSession: jest.fn() },
+    from: jest.fn(),
+  },
+}));
+
+const mockGetSession = supabase.auth.getSession as jest.Mock;
+const mockFrom = supabase.from as jest.Mock;
+
+describe('SupabaseConnector', () => {
+  let connector: SupabaseConnector;
+
+  beforeEach(() => {
+    connector = new SupabaseConnector();
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_POWERSYNC_URL = 'https://ps.example.com';
+  });
+
+  describe('fetchCredentials', () => {
+    it('returns credentials when a session exists', async () => {
+      mockGetSession.mockResolvedValue({
+        data: { session: { access_token: 'test-token', expires_at: 1_000_000 } },
+        error: null,
+      });
+
+      const result = await connector.fetchCredentials();
+
+      expect(result).toEqual({
+        endpoint: 'https://ps.example.com',
+        token: 'test-token',
+        expiresAt: new Date(1_000_000 * 1000),
+      });
+    });
+
+    it('returns null when there is no active session', async () => {
+      mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+
+      const result = await connector.fetchCredentials();
+
+      expect(result).toBeNull();
+    });
+
+    it('omits expiresAt when session has no expires_at', async () => {
+      mockGetSession.mockResolvedValue({
+        data: { session: { access_token: 'test-token', expires_at: undefined } },
+        error: null,
+      });
+
+      const result = await connector.fetchCredentials();
+
+      expect(result?.expiresAt).toBeUndefined();
+    });
+
+    it('throws when getSession returns an error', async () => {
+      mockGetSession.mockResolvedValue({
+        data: { session: null },
+        error: { message: 'network error' },
+      });
+
+      await expect(connector.fetchCredentials()).rejects.toThrow(
+        '[PowerSync] Failed to fetch Supabase session: network error',
+      );
+    });
+  });
+
+  describe('uploadData', () => {
+    const mockComplete = jest.fn().mockResolvedValue(undefined);
+
+    const makeDb = (crud: object[]) => ({
+      getCrudBatch: jest.fn().mockResolvedValue({ crud, complete: mockComplete }),
+    });
+
+    const makeNullDb = () => ({
+      getCrudBatch: jest.fn().mockResolvedValue(null),
+    });
+
+    function setupFromChain() {
+      const eq = jest.fn().mockResolvedValue({});
+      const upsert = jest.fn().mockResolvedValue({});
+      const update = jest.fn().mockReturnValue({ eq });
+      const del = jest.fn().mockReturnValue({ eq });
+      mockFrom.mockReturnValue({ upsert, update, delete: del });
+      return { upsert, update, del, eq };
+    }
+
+    it('returns early without touching supabase when batch is null', async () => {
+      await connector.uploadData(makeNullDb() as never);
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('calls upsert for a PUT operation', async () => {
+      const { upsert } = setupFromChain();
+      const db = makeDb([{ table: 'gardens', op: 'PUT', id: '1', opData: { name: 'Veg bed' } }]);
+
+      await connector.uploadData(db as never);
+
+      expect(mockFrom).toHaveBeenCalledWith('gardens');
+      expect(upsert).toHaveBeenCalledWith({ id: '1', name: 'Veg bed' });
+      expect(mockComplete).toHaveBeenCalled();
+    });
+
+    it('calls update+eq for a PATCH operation', async () => {
+      const { update, eq } = setupFromChain();
+      const db = makeDb([{ table: 'gardens', op: 'PATCH', id: '1', opData: { name: 'Updated' } }]);
+
+      await connector.uploadData(db as never);
+
+      expect(update).toHaveBeenCalledWith({ name: 'Updated' });
+      expect(eq).toHaveBeenCalledWith('id', '1');
+      expect(mockComplete).toHaveBeenCalled();
+    });
+
+    it('calls delete+eq for a DELETE operation', async () => {
+      const { del, eq } = setupFromChain();
+      const db = makeDb([{ table: 'gardens', op: 'DELETE', id: '1', opData: null }]);
+
+      await connector.uploadData(db as never);
+
+      expect(del).toHaveBeenCalled();
+      expect(eq).toHaveBeenCalledWith('id', '1');
+      expect(mockComplete).toHaveBeenCalled();
+    });
+
+    it('always calls batch.complete after processing all entries', async () => {
+      setupFromChain();
+      const db = makeDb([
+        { table: 'gardens', op: 'PUT', id: '1', opData: { name: 'A' } },
+        { table: 'gardens', op: 'DELETE', id: '2', opData: null },
+      ]);
+
+      await connector.uploadData(db as never);
+
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Installed `@powersync/react-native`, `@powersync/common`, `@journeyapps/react-native-quick-sqlite`, `@supabase/supabase-js`
- Added `cjs` to Metro `sourceExts` (required for PowerSync module resolution)
- `src/services/supabase.ts` — typed Supabase client factory, credentials via `EXPO_PUBLIC_*` env vars
- `src/services/powersync.ts` — `SupabaseConnector` implementing `PowerSyncBackendConnector` (`fetchCredentials` + `uploadData`)
- `config/powersync.yaml` — sync rules scaffold with all Phase 1 tables stubbed, ready to uncomment per feature ticket
- `tests/services/powersync.test.ts` — 9 unit tests for `SupabaseConnector`

## Key decision

`@powersync/supabase-connector` does not exist as an npm package. The connector is a custom implementation of `PowerSyncBackendConnector` — the correct PowerSync pattern per their official docs.

## Environment variables required (not committed)

```
EXPO_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
EXPO_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
EXPO_PUBLIC_POWERSYNC_URL=https://<instance>.powersync.journeyapps.com
```

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 11/11 passing (9 new unit tests for `SupabaseConnector`)