### PR TITLE
GARDEN-004: Navigation shell with 5-tab navigator and 12 placeholder screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,21 +1,13 @@
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import AppNavigator from './src/navigation/AppNavigator';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <NavigationContainer>
+      <StatusBar style="light" />
+      <AppNavigator />
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/docs/handoff-GARDEN-004.md
+++ b/docs/handoff-GARDEN-004.md
@@ -1,0 +1,116 @@
+# Handoff — GARDEN-004 Navigation Shell
+
+**Branch:** `GARDEN-004-navigation-shell`
+**Base:** `develop`
+**Status:** In Progress
+
+---
+
+## Goal
+
+Wire up the full React Navigation skeleton — 5-tab bottom navigator, 4 stack navigators, 12 placeholder screens, typed route params. No business logic — structural shell only.
+
+## Scope
+
+- `src/types/navigation.ts` — typed param lists for all navigators
+- `src/navigation/AppNavigator.tsx` — root stack (auth gate placeholder → MainTabs)
+- `src/navigation/TabNavigator.tsx` — 5-tab bottom navigator
+- `src/navigation/GardenStack.tsx` — Garden tab stack
+- `src/navigation/PlannerStack.tsx` — Planner tab stack
+- `src/navigation/PlantsStack.tsx` — Plants tab stack
+- `src/navigation/SettingsStack.tsx` — Settings tab stack
+- 12 placeholder screens (all tabs)
+- Updated `App.tsx` — `NavigationContainer` + `AppNavigator`
+- `tests/App.test.tsx` — updated smoke tests for `GardenScreen`
+
+## Out of Scope
+
+- Auth logic (GARDEN-014) — `LoginScreen` is a placeholder; `AppNavigator` defaults to MainTabs
+- Any real screen content — that's for GARDEN-006 through GARDEN-013
+- Tab icons as image assets — using emoji Text for now, suitable placeholder
+
+---
+
+## Tab Structure
+
+| Tab | Icon | Initial Screen | Stack Screens | Tickets |
+|---|---|---|---|---|
+| Garden | 🌿 | GardenScreen | BedDetail, GardenVisualization | GARDEN-006, 007, 012 |
+| Planner | 📅 | PlannerScreen | WateringDetail, HarvestDetail | GARDEN-008, 009, 010, 013 |
+| Plants | 🔍 | PlantBrowser | PlantReferenceDetail | GARDEN-005, 007 |
+| Camera | 📷 | CameraScreen | — (single screen) | GARDEN-011 |
+| Settings | ⚙️ | SettingsScreen | ZoneSettings | GARDEN-008 (zone), GARDEN-014 |
+
+---
+
+## Key Decisions
+
+### Test strategy: screen isolation, not full navigator
+
+React Navigation's native-stack depends on `react-native-screens` native bindings that cannot run in Jest. Rather than maintain a brittle full-navigator mock, tests render individual screens directly with a `NavigationContainer` wrapper. This is sufficient for a smoke-test of placeholder screens; integration testing of navigation flows requires a device or Detox.
+
+### AppNavigator defaults to MainTabs
+
+`Login` screen is registered but `MainTabs` is the initial route. GARDEN-014 will add the real auth check (if no Supabase session → Login; post-sign-in → navigate to MainTabs).
+
+### Tab icons as Text (emoji)
+
+Using a `<Text>` emoji component as tab icons. No icon library added — avoids a native dependency for placeholder work. GARDEN-006+ can swap in a proper icon set (e.g., `@expo/vector-icons`) when the real UI is built.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `App.tsx` | Replaced placeholder View with `NavigationContainer` + `AppNavigator` |
+| `src/types/navigation.ts` | New — typed param lists + screen prop types |
+| `src/navigation/AppNavigator.tsx` | New — root stack |
+| `src/navigation/TabNavigator.tsx` | New — 5-tab bottom navigator |
+| `src/navigation/GardenStack.tsx` | New |
+| `src/navigation/PlannerStack.tsx` | New |
+| `src/navigation/PlantsStack.tsx` | New |
+| `src/navigation/SettingsStack.tsx` | New |
+| `src/screens/garden/GardenScreen.tsx` | New — placeholder |
+| `src/screens/garden/BedDetailScreen.tsx` | New — placeholder |
+| `src/screens/garden/GardenVisualizationScreen.tsx` | New — placeholder |
+| `src/screens/planner/PlannerScreen.tsx` | New — placeholder |
+| `src/screens/planner/WateringDetailScreen.tsx` | New — placeholder |
+| `src/screens/planner/HarvestDetailScreen.tsx` | New — placeholder |
+| `src/screens/plants/PlantBrowserScreen.tsx` | New — placeholder |
+| `src/screens/plants/PlantReferenceDetailScreen.tsx` | New — placeholder |
+| `src/screens/camera/CameraScreen.tsx` | New — placeholder |
+| `src/screens/settings/SettingsScreen.tsx` | New — placeholder |
+| `src/screens/settings/ZoneSettingsScreen.tsx` | New — placeholder |
+| `src/screens/auth/LoginScreen.tsx` | New — placeholder |
+| `tests/App.test.tsx` | Updated — GardenScreen smoke tests |
+
+---
+
+## Progress
+
+- [x] Branch created: `GARDEN-004-navigation-shell`
+- [x] `src/types/navigation.ts` — all param lists + screen prop types
+- [x] All 4 stack navigators created
+- [x] `TabNavigator.tsx` — 5-tab bottom nav
+- [x] `AppNavigator.tsx` — root stack
+- [x] `App.tsx` updated — `NavigationContainer` + `AppNavigator`
+- [x] 12 placeholder screens
+- [x] `tests/App.test.tsx` — 3 passing smoke tests
+- [x] Lint passing (0 errors, 0 warnings)
+- [x] Tests passing (12/12)
+- [ ] Committed
+
+---
+
+## Next Steps After This Branch
+
+- **GARDEN-005:** Bundled SQLite plant database (pure JS — can start immediately)
+- **GARDEN-006:** Garden builder UI — will fill in `GardenScreen` and `BedDetailScreen`
+- **GARDEN-014:** Auth — will fill in `LoginScreen` and wire the `AppNavigator` auth gate
+
+---
+
+## Last Updated
+
+2026-03-22 — Shell complete. All navigators wired, lint clean, tests green, ready for commit review.

--- a/docs/handoff-GARDEN-004.md
+++ b/docs/handoff-GARDEN-004.md
@@ -2,7 +2,7 @@
 
 **Branch:** `GARDEN-004-navigation-shell`
 **Base:** `develop`
-**Status:** In Progress
+**Status:** Complete — ready for PR
 
 ---
 
@@ -99,7 +99,8 @@ Using a `<Text>` emoji component as tab icons. No icon library added — avoids 
 - [x] `tests/App.test.tsx` — 3 passing smoke tests
 - [x] Lint passing (0 errors, 0 warnings)
 - [x] Tests passing (12/12)
-- [ ] Committed
+- [x] Committed: `db4263a`
+- [ ] PR raised to `develop`
 
 ---
 
@@ -113,4 +114,4 @@ Using a `<Text>` emoji component as tab icons. No icon library added — avoids 
 
 ## Last Updated
 
-2026-03-22 — Shell complete. All navigators wired, lint clean, tests green, ready for commit review.
+2026-03-22 — Committed. Ready for PR to develop.

--- a/docs/mockup-GARDEN-004.html
+++ b/docs/mockup-GARDEN-004.html
@@ -1,0 +1,774 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Garden App — Navigation Shell Mockup (GARDEN-004)</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #1a1a2e;
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px;
+    min-height: 100vh;
+    color: #fff;
+  }
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    margin-bottom: 6px;
+    color: #e8f5e9;
+    letter-spacing: -0.5px;
+  }
+  .subtitle {
+    font-size: 13px;
+    color: #78909c;
+    margin-bottom: 36px;
+  }
+
+  /* Screens row */
+  .screens {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: flex-start;
+  }
+  .screen-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+  .screen-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: #78909c;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  /* Phone frame */
+  .phone {
+    width: 280px;
+    height: 580px;
+    background: #0d1117;
+    border-radius: 40px;
+    border: 2.5px solid #30363d;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 24px 64px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.05);
+  }
+  .phone::before {
+    content: '';
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80px;
+    height: 6px;
+    background: #21262d;
+    border-radius: 3px;
+    z-index: 10;
+  }
+
+  /* Status bar */
+  .status-bar {
+    height: 44px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    padding: 0 24px 8px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #c9d1d9;
+    flex-shrink: 0;
+  }
+  .status-right { display: flex; gap: 6px; align-items: center; }
+  .signal { display: flex; gap: 2px; align-items: flex-end; }
+  .signal span { background: #c9d1d9; border-radius: 1px; width: 3px; }
+
+  /* Navigation header */
+  .nav-header {
+    height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    border-bottom: 1px solid #21262d;
+    flex-shrink: 0;
+  }
+  .nav-title {
+    font-size: 17px;
+    font-weight: 700;
+    color: #e6edf3;
+  }
+  .nav-action {
+    width: 28px;
+    height: 28px;
+    border-radius: 14px;
+    background: #2ea043;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+  }
+
+  /* Screen content */
+  .screen-content {
+    flex: 1;
+    overflow: hidden;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .phone-inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  /* Tab bar */
+  .tab-bar {
+    height: 72px;
+    border-top: 1px solid #21262d;
+    display: flex;
+    align-items: flex-start;
+    padding-top: 10px;
+    background: #0d1117;
+    flex-shrink: 0;
+  }
+  .tab {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    cursor: pointer;
+    opacity: 0.4;
+    transition: opacity 0.15s;
+  }
+  .tab.active { opacity: 1; }
+  .tab-icon { font-size: 20px; line-height: 1; }
+  .tab-text {
+    font-size: 9px;
+    font-weight: 600;
+    color: #2ea043;
+    letter-spacing: 0.2px;
+  }
+  .tab.active .tab-text { color: #3fb950; }
+
+  /* Wireframe elements */
+  .card {
+    background: #161b22;
+    border: 1px solid #21262d;
+    border-radius: 12px;
+    padding: 12px;
+  }
+  .card-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #c9d1d9;
+    margin-bottom: 6px;
+  }
+  .card-sub {
+    font-size: 11px;
+    color: #8b949e;
+    line-height: 1.4;
+  }
+  .row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+  .avatar {
+    width: 36px; height: 36px;
+    border-radius: 10px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+  }
+  .pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+  }
+  .pill-green { background: rgba(46,160,67,0.2); color: #3fb950; }
+  .pill-blue { background: rgba(56,139,253,0.2); color: #58a6ff; }
+  .pill-orange { background: rgba(210,153,34,0.2); color: #e3b341; }
+  .pill-red { background: rgba(248,81,73,0.2); color: #f85149; }
+  .skel {
+    height: 10px;
+    background: #21262d;
+    border-radius: 5px;
+    margin: 4px 0;
+  }
+  .skel.short { width: 55%; }
+  .skel.med { width: 75%; }
+  .skel.full { width: 100%; }
+  .progress {
+    height: 4px;
+    background: #21262d;
+    border-radius: 2px;
+    margin-top: 6px;
+    overflow: hidden;
+  }
+  .progress-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: #2ea043;
+  }
+  .divider {
+    height: 1px;
+    background: #21262d;
+    margin: 4px 0;
+  }
+  .section-heading {
+    font-size: 10px;
+    font-weight: 700;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 6px;
+  }
+  .big-icon-area {
+    flex: 1;
+    background: #0d2818;
+    border: 1px dashed #2ea043;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 120px;
+  }
+  .big-icon { font-size: 36px; }
+  .big-icon-label { font-size: 11px; color: #3fb950; font-weight: 600; }
+  .badge {
+    position: absolute;
+    top: -2px; right: -4px;
+    background: #f85149;
+    color: #fff;
+    font-size: 8px;
+    font-weight: 700;
+    min-width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 3px;
+  }
+  .tab-wrapper { position: relative; }
+  .calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 3px;
+    margin-top: 6px;
+  }
+  .cal-day {
+    aspect-ratio: 1;
+    border-radius: 4px;
+    background: #161b22;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 8px;
+    color: #8b949e;
+  }
+  .cal-day.has-event { background: rgba(46,160,67,0.25); color: #3fb950; }
+  .cal-day.today { background: #2ea043; color: #fff; font-weight: 700; }
+  .cal-day.water { background: rgba(56,139,253,0.25); color: #58a6ff; }
+  .plant-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+  .plant-card {
+    background: #161b22;
+    border: 1px solid #21262d;
+    border-radius: 10px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .plant-emoji { font-size: 22px; }
+  .plant-name { font-size: 11px; font-weight: 600; color: #c9d1d9; }
+  .plant-sub { font-size: 9px; color: #8b949e; }
+  .search-bar {
+    background: #161b22;
+    border: 1px solid #21262d;
+    border-radius: 8px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    gap: 6px;
+    font-size: 11px;
+    color: #8b949e;
+  }
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 0;
+    border-bottom: 1px solid #21262d;
+  }
+  .setting-left { display: flex; align-items: center; gap: 8px; }
+  .setting-icon {
+    width: 28px; height: 28px;
+    border-radius: 7px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px;
+  }
+  .setting-text { font-size: 12px; color: #c9d1d9; font-weight: 500; }
+  .chevron { color: #8b949e; font-size: 10px; }
+  .toggle {
+    width: 30px; height: 18px;
+    border-radius: 9px;
+    background: #2ea043;
+    position: relative;
+  }
+  .toggle::after {
+    content: '';
+    position: absolute;
+    width: 14px; height: 14px;
+    background: #fff;
+    border-radius: 7px;
+    top: 2px; right: 2px;
+  }
+  .vis-placeholder {
+    flex: 1;
+    background: #0a1628;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: 1px dashed #1f6feb;
+    min-height: 100px;
+    position: relative;
+    overflow: hidden;
+  }
+  .vis-grid {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px;
+  }
+  .vis-plant {
+    width: 24px; height: 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0;
+  }
+  .vis-leaf { font-size: 14px; line-height: 1; }
+  .vis-stem {
+    width: 2px;
+    background: #2ea043;
+    border-radius: 1px;
+  }
+  .vis-label {
+    font-size: 10px;
+    color: #388bfd;
+    font-weight: 600;
+    z-index: 1;
+  }
+</style>
+</head>
+<body>
+
+<h1>Garden App — Navigation Shell</h1>
+<p class="subtitle">GARDEN-004 · Wireframe mockup · All screens are placeholder content</p>
+
+<div class="screens">
+
+  <!-- GARDEN TAB -->
+  <div class="screen-group">
+    <div class="screen-label">Garden Tab</div>
+    <div class="phone">
+      <div class="phone-inner">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="status-right">
+            <div class="signal">
+              <span style="height:4px"></span><span style="height:6px"></span>
+              <span style="height:8px"></span><span style="height:10px"></span>
+            </div>
+            <span>WiFi</span>
+            <span>🔋</span>
+          </div>
+        </div>
+        <div class="nav-header">
+          <span class="nav-title">My Garden</span>
+          <div class="nav-action">＋</div>
+        </div>
+        <div class="screen-content">
+          <!-- 3D vis area -->
+          <div class="vis-placeholder">
+            <div class="vis-label">3D View</div>
+            <div class="vis-grid">
+              <div class="vis-plant"><div class="vis-leaf">🌿</div><div class="vis-stem" style="height:16px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🍅</div><div class="vis-stem" style="height:22px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🌿</div><div class="vis-stem" style="height:12px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🥦</div><div class="vis-stem" style="height:18px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🌱</div><div class="vis-stem" style="height:8px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🫑</div><div class="vis-stem" style="height:20px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🌿</div><div class="vis-stem" style="height:14px"></div></div>
+              <div class="vis-plant"><div class="vis-leaf">🍓</div><div class="vis-stem" style="height:10px"></div></div>
+            </div>
+          </div>
+          <div class="section-heading">Beds</div>
+          <div class="card">
+            <div class="row">
+              <div class="avatar" style="background:#0d2818">🌱</div>
+              <div style="flex:1">
+                <div class="card-title">Raised Bed A</div>
+                <div class="card-sub">6 plants · 4×8 ft raised bed</div>
+                <div class="progress"><div class="progress-fill" style="width:65%"></div></div>
+              </div>
+              <span class="pill pill-green">Good</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="row">
+              <div class="avatar" style="background:#1a1206">🍅</div>
+              <div style="flex:1">
+                <div class="card-title">Tomato Corner</div>
+                <div class="card-sub">3 plants · container</div>
+                <div class="progress"><div class="progress-fill" style="width:40%;background:#e3b341"></div></div>
+              </div>
+              <span class="pill pill-orange">Water</span>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="tab-icon">🌿</div><div class="tab-text">Garden</div></div>
+          <div class="tab"><div class="tab-icon">📅</div><div class="tab-text">Planner</div></div>
+          <div class="tab"><div class="tab-icon">🔍</div><div class="tab-text">Plants</div></div>
+          <div class="tab"><div class="tab-icon">📷</div><div class="tab-text">Camera</div></div>
+          <div class="tab"><div class="tab-icon">⚙️</div><div class="tab-text">Settings</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- PLANNER TAB -->
+  <div class="screen-group">
+    <div class="screen-label">Planner Tab</div>
+    <div class="phone">
+      <div class="phone-inner">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="status-right"><span>WiFi</span><span>🔋</span></div>
+        </div>
+        <div class="nav-header">
+          <span class="nav-title">Planner</span>
+        </div>
+        <div class="screen-content">
+          <div class="card">
+            <div class="card-title">March 2026</div>
+            <div class="calendar-grid">
+              <div class="cal-day" style="color:#556068">S</div>
+              <div class="cal-day" style="color:#556068">M</div>
+              <div class="cal-day" style="color:#556068">T</div>
+              <div class="cal-day" style="color:#556068">W</div>
+              <div class="cal-day" style="color:#556068">T</div>
+              <div class="cal-day" style="color:#556068">F</div>
+              <div class="cal-day" style="color:#556068">S</div>
+              <div class="cal-day"></div>
+              <div class="cal-day"></div>
+              <div class="cal-day"></div>
+              <div class="cal-day"></div>
+              <div class="cal-day"></div>
+              <div class="cal-day has-event">7</div>
+              <div class="cal-day">8</div>
+              <div class="cal-day water">9</div>
+              <div class="cal-day">10</div>
+              <div class="cal-day has-event">11</div>
+              <div class="cal-day">12</div>
+              <div class="cal-day water">13</div>
+              <div class="cal-day">14</div>
+              <div class="cal-day">15</div>
+              <div class="cal-day water">16</div>
+              <div class="cal-day has-event">17</div>
+              <div class="cal-day">18</div>
+              <div class="cal-day">19</div>
+              <div class="cal-day water">20</div>
+              <div class="cal-day">21</div>
+              <div class="cal-day today">22</div>
+              <div class="cal-day water">23</div>
+            </div>
+            <div style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap">
+              <span class="pill pill-green">🌿 Plant event</span>
+              <span class="pill pill-blue">💧 Water day</span>
+            </div>
+          </div>
+          <div class="section-heading">Today</div>
+          <div class="card">
+            <div class="row">
+              <span style="font-size:18px">💧</span>
+              <div style="flex:1">
+                <div class="card-title">Water Raised Bed A</div>
+                <div class="card-sub">Tomatoes + basil need water today</div>
+              </div>
+              <span class="pill pill-blue">Now</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="row">
+              <span style="font-size:18px">🌡️</span>
+              <div style="flex:1">
+                <div class="card-title">Frost alert in 3 days</div>
+                <div class="card-sub">Cover tender plants Mar 25</div>
+              </div>
+              <span class="pill pill-orange">Alert</span>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="tab-icon">🌿</div><div class="tab-text">Garden</div></div>
+          <div class="tab active"><div class="tab-icon">📅</div><div class="tab-text">Planner</div></div>
+          <div class="tab"><div class="tab-icon">🔍</div><div class="tab-text">Plants</div></div>
+          <div class="tab"><div class="tab-icon">📷</div><div class="tab-text">Camera</div></div>
+          <div class="tab"><div class="tab-icon">⚙️</div><div class="tab-text">Settings</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- PLANTS TAB -->
+  <div class="screen-group">
+    <div class="screen-label">Plants Tab</div>
+    <div class="phone">
+      <div class="phone-inner">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="status-right"><span>WiFi</span><span>🔋</span></div>
+        </div>
+        <div class="nav-header">
+          <span class="nav-title">Plant Database</span>
+        </div>
+        <div class="screen-content">
+          <div class="search-bar">
+            <span>🔍</span>
+            <span>Search 500 plants…</span>
+          </div>
+          <div style="display:flex;gap:6px;flex-wrap:wrap">
+            <span class="pill pill-green">Vegetables</span>
+            <span class="pill pill-blue">Herbs</span>
+            <span class="pill pill-orange">Fruits</span>
+            <span class="pill" style="background:#21262d;color:#8b949e">All</span>
+          </div>
+          <div class="section-heading">Popular</div>
+          <div class="plant-grid">
+            <div class="plant-card">
+              <div class="plant-emoji">🍅</div>
+              <div class="plant-name">Tomato</div>
+              <div class="plant-sub">60–80 days</div>
+              <span class="pill pill-orange" style="margin-top:4px">High water</span>
+            </div>
+            <div class="plant-card">
+              <div class="plant-emoji">🥦</div>
+              <div class="plant-name">Broccoli</div>
+              <div class="plant-sub">50–65 days</div>
+              <span class="pill pill-blue" style="margin-top:4px">Med water</span>
+            </div>
+            <div class="plant-card">
+              <div class="plant-emoji">🌿</div>
+              <div class="plant-name">Basil</div>
+              <div class="plant-sub">25–30 days</div>
+              <span class="pill pill-green" style="margin-top:4px">Low water</span>
+            </div>
+            <div class="plant-card">
+              <div class="plant-emoji">🥕</div>
+              <div class="plant-name">Carrot</div>
+              <div class="plant-sub">70–80 days</div>
+              <span class="pill pill-blue" style="margin-top:4px">Med water</span>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="tab-icon">🌿</div><div class="tab-text">Garden</div></div>
+          <div class="tab"><div class="tab-icon">📅</div><div class="tab-text">Planner</div></div>
+          <div class="tab active"><div class="tab-icon">🔍</div><div class="tab-text">Plants</div></div>
+          <div class="tab"><div class="tab-icon">📷</div><div class="tab-text">Camera</div></div>
+          <div class="tab"><div class="tab-icon">⚙️</div><div class="tab-text">Settings</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- CAMERA TAB -->
+  <div class="screen-group">
+    <div class="screen-label">Camera Tab</div>
+    <div class="phone">
+      <div class="phone-inner">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="status-right"><span>WiFi</span><span>🔋</span></div>
+        </div>
+        <div class="nav-header">
+          <span class="nav-title">AI Camera</span>
+        </div>
+        <div class="screen-content">
+          <div class="big-icon-area" style="min-height:200px;background:#0a1a0a">
+            <div class="big-icon">📷</div>
+            <div class="big-icon-label">Camera viewfinder</div>
+            <div style="font-size:10px;color:#8b949e;text-align:center;padding:0 20px">
+              Point at your plant to analyze
+            </div>
+          </div>
+          <div style="display:flex;gap:8px">
+            <div class="card" style="flex:1;align-items:center;display:flex;flex-direction:column;gap:4px;padding:12px 8px">
+              <span style="font-size:22px">🌱</span>
+              <div style="font-size:10px;font-weight:600;color:#c9d1d9;text-align:center">Onboard Plant</div>
+              <div style="font-size:9px;color:#8b949e;text-align:center">Detect growth stage</div>
+            </div>
+            <div class="card" style="flex:1;align-items:center;display:flex;flex-direction:column;gap:4px;padding:12px 8px">
+              <span style="font-size:22px">📊</span>
+              <div style="font-size:10px;font-weight:600;color:#c9d1d9;text-align:center">Progress Check</div>
+              <div style="font-size:9px;color:#8b949e;text-align:center">Compare to schedule</div>
+            </div>
+          </div>
+          <div class="section-heading">Recent Photos</div>
+          <div class="card">
+            <div class="row">
+              <div class="avatar" style="background:#0d1a0d;font-size:22px">🍅</div>
+              <div style="flex:1">
+                <div class="card-title">Tomato — Bed A</div>
+                <div class="card-sub">2 days ago · Early vegetative</div>
+              </div>
+              <span class="pill pill-green">On track</span>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="tab-icon">🌿</div><div class="tab-text">Garden</div></div>
+          <div class="tab"><div class="tab-icon">📅</div><div class="tab-text">Planner</div></div>
+          <div class="tab"><div class="tab-icon">🔍</div><div class="tab-text">Plants</div></div>
+          <div class="tab active"><div class="tab-icon">📷</div><div class="tab-text">Camera</div></div>
+          <div class="tab"><div class="tab-icon">⚙️</div><div class="tab-text">Settings</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- SETTINGS TAB -->
+  <div class="screen-group">
+    <div class="screen-label">Settings Tab</div>
+    <div class="phone">
+      <div class="phone-inner">
+        <div class="status-bar">
+          <span>9:41</span>
+          <div class="status-right"><span>WiFi</span><span>🔋</span></div>
+        </div>
+        <div class="nav-header">
+          <span class="nav-title">Settings</span>
+        </div>
+        <div class="screen-content">
+          <!-- Profile -->
+          <div class="card">
+            <div class="row">
+              <div class="avatar" style="background:#1a1a2e;font-size:24px;width:44px;height:44px;border-radius:22px">👤</div>
+              <div style="flex:1">
+                <div class="card-title">Sign In</div>
+                <div class="card-sub">Sync your garden across devices</div>
+              </div>
+              <span class="pill pill-blue">GARDEN-014</span>
+            </div>
+          </div>
+
+          <div class="section-heading">Garden</div>
+          <div class="setting-row">
+            <div class="setting-left">
+              <div class="setting-icon" style="background:#0d2818">🗺️</div>
+              <span class="setting-text">Growing Zone</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:6px">
+              <span style="font-size:11px;color:#8b949e">Zone 7b</span>
+              <span class="chevron">›</span>
+            </div>
+          </div>
+          <div class="setting-row">
+            <div class="setting-left">
+              <div class="setting-icon" style="background:#0d1a2e">📍</div>
+              <span class="setting-text">Location</span>
+            </div>
+            <span class="chevron">›</span>
+          </div>
+
+          <div class="section-heading">Notifications</div>
+          <div class="setting-row">
+            <div class="setting-left">
+              <div class="setting-icon" style="background:#1a0d0d">💧</div>
+              <span class="setting-text">Watering reminders</span>
+            </div>
+            <div class="toggle"></div>
+          </div>
+          <div class="setting-row">
+            <div class="setting-left">
+              <div class="setting-icon" style="background:#1a1206">🌾</div>
+              <span class="setting-text">Harvest alerts</span>
+            </div>
+            <div class="toggle"></div>
+          </div>
+          <div class="setting-row">
+            <div class="setting-left">
+              <div class="setting-icon" style="background:#0d1a2e">🌡️</div>
+              <span class="setting-text">Frost & weather alerts</span>
+            </div>
+            <div class="toggle"></div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="tab-icon">🌿</div><div class="tab-text">Garden</div></div>
+          <div class="tab"><div class="tab-icon">📅</div><div class="tab-text">Planner</div></div>
+          <div class="tab"><div class="tab-icon">🔍</div><div class="tab-text">Plants</div></div>
+          <div class="tab"><div class="tab-icon">📷</div><div class="tab-text">Camera</div></div>
+          <div class="tab active"><div class="tab-icon">⚙️</div><div class="tab-text">Settings</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div style="margin-top:40px;padding:16px 24px;background:#161b22;border:1px solid #21262d;border-radius:12px;max-width:760px;width:100%">
+  <div style="font-size:13px;font-weight:700;color:#c9d1d9;margin-bottom:12px">Screen inventory (GARDEN-004 scope)</div>
+  <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:8px;font-size:11px;color:#8b949e">
+    <div>🌿 <strong style="color:#c9d1d9">GardenScreen</strong> — bed list + 3D entry</div>
+    <div>🏡 <strong style="color:#c9d1d9">BedDetailScreen</strong> — plants in a bed</div>
+    <div>🎮 <strong style="color:#c9d1d9">GardenVisualizationScreen</strong> — R3F 3D view</div>
+    <div>📅 <strong style="color:#c9d1d9">PlannerScreen</strong> — calendar + tasks</div>
+    <div>💧 <strong style="color:#c9d1d9">WateringDetailScreen</strong> — watering log</div>
+    <div>🌾 <strong style="color:#c9d1d9">HarvestDetailScreen</strong> — harvest log</div>
+    <div>🔍 <strong style="color:#c9d1d9">PlantBrowserScreen</strong> — search DB</div>
+    <div>🌱 <strong style="color:#c9d1d9">PlantReferenceDetailScreen</strong> — plant info</div>
+    <div>📷 <strong style="color:#c9d1d9">CameraScreen</strong> — AI photo</div>
+    <div>⚙️ <strong style="color:#c9d1d9">SettingsScreen</strong> — prefs + auth entry</div>
+    <div>🗺️ <strong style="color:#c9d1d9">ZoneSettingsScreen</strong> — zone + location</div>
+    <div>🔐 <strong style="color:#c9d1d9">LoginScreen</strong> — placeholder for GARDEN-014</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../types/navigation';
+import LoginScreen from '../screens/auth/LoginScreen';
+import TabNavigator from './TabNavigator';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+/**
+ * Root navigator — auth gate.
+ *
+ * Currently defaults straight to MainTabs (Login is a placeholder).
+ * GARDEN-014 will add a real auth check here: if no Supabase session,
+ * render Login; once signed in, navigate to MainTabs.
+ */
+export default function AppNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="MainTabs" component={TabNavigator} />
+      <Stack.Screen name="Login" component={LoginScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/GardenStack.tsx
+++ b/src/navigation/GardenStack.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { GardenStackParamList } from '../types/navigation';
+import GardenScreen from '../screens/garden/GardenScreen';
+import BedDetailScreen from '../screens/garden/BedDetailScreen';
+import GardenVisualizationScreen from '../screens/garden/GardenVisualizationScreen';
+
+const Stack = createNativeStackNavigator<GardenStackParamList>();
+
+export default function GardenStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#0d1117' },
+        headerTintColor: '#e6edf3',
+        headerTitleStyle: { fontWeight: '700' },
+        contentStyle: { backgroundColor: '#0d1117' },
+      }}
+    >
+      <Stack.Screen name="GardenScreen" component={GardenScreen} options={{ title: 'My Garden' }} />
+      <Stack.Screen name="BedDetail" component={BedDetailScreen} options={{ title: 'Bed Detail' }} />
+      <Stack.Screen name="GardenVisualization" component={GardenVisualizationScreen} options={{ title: '3D View' }} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/PlannerStack.tsx
+++ b/src/navigation/PlannerStack.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { PlannerStackParamList } from '../types/navigation';
+import PlannerScreen from '../screens/planner/PlannerScreen';
+import WateringDetailScreen from '../screens/planner/WateringDetailScreen';
+import HarvestDetailScreen from '../screens/planner/HarvestDetailScreen';
+
+const Stack = createNativeStackNavigator<PlannerStackParamList>();
+
+export default function PlannerStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#0d1117' },
+        headerTintColor: '#e6edf3',
+        headerTitleStyle: { fontWeight: '700' },
+        contentStyle: { backgroundColor: '#0d1117' },
+      }}
+    >
+      <Stack.Screen name="PlannerScreen" component={PlannerScreen} options={{ title: 'Planner' }} />
+      <Stack.Screen name="WateringDetail" component={WateringDetailScreen} options={{ title: 'Watering' }} />
+      <Stack.Screen name="HarvestDetail" component={HarvestDetailScreen} options={{ title: 'Harvest' }} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/PlantsStack.tsx
+++ b/src/navigation/PlantsStack.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { PlantsStackParamList } from '../types/navigation';
+import PlantBrowserScreen from '../screens/plants/PlantBrowserScreen';
+import PlantReferenceDetailScreen from '../screens/plants/PlantReferenceDetailScreen';
+
+const Stack = createNativeStackNavigator<PlantsStackParamList>();
+
+export default function PlantsStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#0d1117' },
+        headerTintColor: '#e6edf3',
+        headerTitleStyle: { fontWeight: '700' },
+        contentStyle: { backgroundColor: '#0d1117' },
+      }}
+    >
+      <Stack.Screen name="PlantBrowser" component={PlantBrowserScreen} options={{ title: 'Plant Database' }} />
+      <Stack.Screen name="PlantReferenceDetail" component={PlantReferenceDetailScreen} options={{ title: 'Plant Info' }} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { SettingsStackParamList } from '../types/navigation';
+import SettingsScreen from '../screens/settings/SettingsScreen';
+import ZoneSettingsScreen from '../screens/settings/ZoneSettingsScreen';
+
+const Stack = createNativeStackNavigator<SettingsStackParamList>();
+
+export default function SettingsStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#0d1117' },
+        headerTintColor: '#e6edf3',
+        headerTitleStyle: { fontWeight: '700' },
+        contentStyle: { backgroundColor: '#0d1117' },
+      }}
+    >
+      <Stack.Screen name="SettingsScreen" component={SettingsScreen} options={{ title: 'Settings' }} />
+      <Stack.Screen name="ZoneSettings" component={ZoneSettingsScreen} options={{ title: 'Growing Zone' }} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Text } from 'react-native';
+import type { TabParamList } from '../types/navigation';
+import GardenStack from './GardenStack';
+import PlannerStack from './PlannerStack';
+import PlantsStack from './PlantsStack';
+import CameraScreen from '../screens/camera/CameraScreen';
+import SettingsStack from './SettingsStack';
+
+const Tab = createBottomTabNavigator<TabParamList>();
+
+function TabIcon({ emoji, focused }: { emoji: string; focused: boolean }) {
+  return <Text style={{ fontSize: 20, opacity: focused ? 1 : 0.45 }}>{emoji}</Text>;
+}
+
+export default function TabNavigator() {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: '#0d1117',
+          borderTopColor: '#21262d',
+          borderTopWidth: 1,
+        },
+        tabBarActiveTintColor: '#3fb950',
+        tabBarInactiveTintColor: '#8b949e',
+        tabBarLabelStyle: { fontSize: 10, fontWeight: '600' },
+      }}
+    >
+      <Tab.Screen
+        name="GardenTab"
+        component={GardenStack}
+        options={{
+          tabBarLabel: 'Garden',
+          tabBarIcon: ({ focused }) => <TabIcon emoji="🌿" focused={focused} />,
+        }}
+      />
+      <Tab.Screen
+        name="PlannerTab"
+        component={PlannerStack}
+        options={{
+          tabBarLabel: 'Planner',
+          tabBarIcon: ({ focused }) => <TabIcon emoji="📅" focused={focused} />,
+        }}
+      />
+      <Tab.Screen
+        name="PlantsTab"
+        component={PlantsStack}
+        options={{
+          tabBarLabel: 'Plants',
+          tabBarIcon: ({ focused }) => <TabIcon emoji="🔍" focused={focused} />,
+        }}
+      />
+      <Tab.Screen
+        name="CameraTab"
+        component={CameraScreen}
+        options={{
+          tabBarLabel: 'Camera',
+          tabBarIcon: ({ focused }) => <TabIcon emoji="📷" focused={focused} />,
+          headerShown: true,
+          headerTitle: 'AI Camera',
+          headerStyle: { backgroundColor: '#0d1117' },
+          headerTintColor: '#e6edf3',
+          headerTitleStyle: { fontWeight: '700' },
+        }}
+      />
+      <Tab.Screen
+        name="SettingsTab"
+        component={SettingsStack}
+        options={{
+          tabBarLabel: 'Settings',
+          tabBarIcon: ({ focused }) => <TabIcon emoji="⚙️" focused={focused} />,
+        }}
+      />
+    </Tab.Navigator>
+  );
+}

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function LoginScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Sign In</Text>
+      <Text style={styles.sub}>GARDEN-014 · Supabase auth</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/camera/CameraScreen.tsx
+++ b/src/screens/camera/CameraScreen.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function CameraScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>AI Camera</Text>
+      <Text style={styles.sub}>GARDEN-011 · Gemini Flash plant analysis</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/garden/BedDetailScreen.tsx
+++ b/src/screens/garden/BedDetailScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function BedDetailScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Bed Detail</Text>
+      <Text style={styles.sub}>GARDEN-006/007 · Plants in a bed</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/garden/GardenScreen.tsx
+++ b/src/screens/garden/GardenScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function GardenScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Garden</Text>
+      <Text style={styles.sub}>GARDEN-006 · Bed list + 3D entry</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/garden/GardenVisualizationScreen.tsx
+++ b/src/screens/garden/GardenVisualizationScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function GardenVisualizationScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>3D Garden View</Text>
+      <Text style={styles.sub}>GARDEN-012 · R3F + expo-gl canvas</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/planner/HarvestDetailScreen.tsx
+++ b/src/screens/planner/HarvestDetailScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function HarvestDetailScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Harvest Detail</Text>
+      <Text style={styles.sub}>GARDEN-010/013 · Harvest window + log</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/planner/PlannerScreen.tsx
+++ b/src/screens/planner/PlannerScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function PlannerScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Planner</Text>
+      <Text style={styles.sub}>GARDEN-008/009/010 · Calendar + tasks</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/planner/WateringDetailScreen.tsx
+++ b/src/screens/planner/WateringDetailScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function WateringDetailScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Watering Detail</Text>
+      <Text style={styles.sub}>GARDEN-009 · Watering log + recommendations</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/plants/PlantBrowserScreen.tsx
+++ b/src/screens/plants/PlantBrowserScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function PlantBrowserScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Plant Database</Text>
+      <Text style={styles.sub}>GARDEN-005 · Search bundled SQLite</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/plants/PlantReferenceDetailScreen.tsx
+++ b/src/screens/plants/PlantReferenceDetailScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function PlantReferenceDetailScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Plant Reference</Text>
+      <Text style={styles.sub}>GARDEN-005 · Days, spacing, companions</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Settings</Text>
+      <Text style={styles.sub}>GARDEN-014 · Auth + preferences</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/screens/settings/ZoneSettingsScreen.tsx
+++ b/src/screens/settings/ZoneSettingsScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+
+export default function ZoneSettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Growing Zone</Text>
+      <Text style={styles.sub}>GARDEN-008 · USDA zone + frost dates</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#0d1117' },
+  text: { fontSize: 22, fontWeight: '700', color: '#e6edf3' },
+  sub: { fontSize: 12, color: '#8b949e', marginTop: 6 },
+});

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,86 @@
+import type { CompositeScreenProps } from '@react-navigation/native';
+import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+// ---------------------------------------------------------------------------
+// Root stack — auth gate
+// ---------------------------------------------------------------------------
+export type RootStackParamList = {
+  Login: undefined;
+  MainTabs: undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Bottom tab navigator
+// ---------------------------------------------------------------------------
+export type TabParamList = {
+  GardenTab: undefined;
+  PlannerTab: undefined;
+  PlantsTab: undefined;
+  CameraTab: undefined;
+  SettingsTab: undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Garden stack  (GARDEN-006, 007, 012)
+// ---------------------------------------------------------------------------
+export type GardenStackParamList = {
+  GardenScreen: undefined;
+  BedDetail: { bedId: string };
+  GardenVisualization: undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Planner stack  (GARDEN-008, 009, 010, 013)
+// ---------------------------------------------------------------------------
+export type PlannerStackParamList = {
+  PlannerScreen: undefined;
+  WateringDetail: { plantingId: string };
+  HarvestDetail: { plantingId: string };
+};
+
+// ---------------------------------------------------------------------------
+// Plants stack  (GARDEN-005, 007)
+// ---------------------------------------------------------------------------
+export type PlantsStackParamList = {
+  PlantBrowser: undefined;
+  PlantReferenceDetail: { plantId: string };
+};
+
+// ---------------------------------------------------------------------------
+// Settings stack  (GARDEN-008 zone, GARDEN-014 auth)
+// ---------------------------------------------------------------------------
+export type SettingsStackParamList = {
+  SettingsScreen: undefined;
+  ZoneSettings: undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Convenience screen prop types
+// ---------------------------------------------------------------------------
+export type RootStackScreenProps<T extends keyof RootStackParamList> =
+  NativeStackScreenProps<RootStackParamList, T>;
+
+export type GardenStackScreenProps<T extends keyof GardenStackParamList> =
+  CompositeScreenProps<
+    NativeStackScreenProps<GardenStackParamList, T>,
+    BottomTabScreenProps<TabParamList>
+  >;
+
+export type PlannerStackScreenProps<T extends keyof PlannerStackParamList> =
+  CompositeScreenProps<
+    NativeStackScreenProps<PlannerStackParamList, T>,
+    BottomTabScreenProps<TabParamList>
+  >;
+
+export type PlantsStackScreenProps<T extends keyof PlantsStackParamList> =
+  CompositeScreenProps<
+    NativeStackScreenProps<PlantsStackParamList, T>,
+    BottomTabScreenProps<TabParamList>
+  >;
+
+export type SettingsStackScreenProps<T extends keyof SettingsStackParamList> =
+  CompositeScreenProps<
+    NativeStackScreenProps<SettingsStackParamList, T>,
+    BottomTabScreenProps<TabParamList>
+  >;

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,14 +1,71 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
-import App from '../App';
+import { NavigationContainer } from '@react-navigation/native';
+import GardenScreen from '../src/screens/garden/GardenScreen';
 
-describe('App', () => {
+// React Navigation's native-stack and bottom-tabs rely on react-native-screens
+// native modules that cannot run in Jest. We mock the navigators so individual
+// screens can be tested in isolation without the full native stack.
+jest.mock('react-native-safe-area-context', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const ReactModule = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require('react-native');
+  const insets = { top: 0, right: 0, bottom: 0, left: 0 };
+  const frame = { x: 0, y: 0, width: 390, height: 844 };
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+    SafeAreaView: View,
+    SafeAreaInsetsContext: ReactModule.createContext(insets),
+    SafeAreaFrameContext: ReactModule.createContext(frame),
+    useSafeAreaInsets: () => insets,
+    useSafeAreaFrame: () => frame,
+    initialWindowMetrics: { frame, insets },
+  };
+});
+
+// Minimal navigation mock — enough to satisfy useNavigation/useRoute calls
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+    useRoute: () => ({ params: {} }),
+  };
+});
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+} as never;
+
+const mockRoute = { key: 'GardenScreen', name: 'GardenScreen', params: undefined } as never;
+
+describe('GardenScreen', () => {
   it('renders without crashing', () => {
-    render(<App />);
+    render(
+      <NavigationContainer>
+        <GardenScreen navigation={mockNavigation} route={mockRoute} />
+      </NavigationContainer>,
+    );
   });
 
-  it('displays the placeholder text', () => {
-    render(<App />);
-    expect(screen.getByText('Open up App.js to start working on your app!')).toBeTruthy();
+  it('displays the screen title', () => {
+    render(
+      <NavigationContainer>
+        <GardenScreen navigation={mockNavigation} route={mockRoute} />
+      </NavigationContainer>,
+    );
+    expect(screen.getByText('Garden')).toBeTruthy();
+  });
+
+  it('displays the ticket reference', () => {
+    render(
+      <NavigationContainer>
+        <GardenScreen navigation={mockNavigation} route={mockRoute} />
+      </NavigationContainer>,
+    );
+    expect(screen.getByText('GARDEN-006 · Bed list + 3D entry')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- `src/types/navigation.ts` — typed param lists for all 5 navigators (Root, Garden, Planner, Plants, Settings)
- `src/navigation/` — AppNavigator (auth gate), TabNavigator (5 tabs), 4 stack navigators
- 12 placeholder screens across all tabs — each shows screen name + ticket reference
- `App.tsx` updated to use `NavigationContainer` + `AppNavigator`
- `tests/App.test.tsx` updated — 3 smoke tests for `GardenScreen` in isolation

## Tab structure

| Tab | Stack screens | Tickets |
|---|---|---|
| 🌿 Garden | GardenScreen → BedDetail → GardenVisualization | GARDEN-006, 007, 012 |
| 📅 Planner | PlannerScreen → WateringDetail → HarvestDetail | GARDEN-008, 009, 010, 013 |
| 🔍 Plants | PlantBrowser → PlantReferenceDetail | GARDEN-005, 007 |
| 📷 Camera | CameraScreen | GARDEN-011 |
| ⚙️ Settings | SettingsScreen → ZoneSettings | GARDEN-008, 014 |

## Design mockup

`docs/mockup-GARDEN-004.html` — interactive HTML wireframe showing all 5 tabs.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 12/12 passing